### PR TITLE
[#21] MySQL 실행 계획을 적용한 쿼리 튜닝

### DIFF
--- a/src/main/java/com/ludensdomain/dto/GameDto.java
+++ b/src/main/java/com/ludensdomain/dto/GameDto.java
@@ -36,7 +36,7 @@ public class GameDto {
     @NotEmpty(message = "배급사를 입력하세요.")
     long publisher;
 
-    int rating;
+    double rating;
 
     int sales;
 

--- a/src/main/java/com/ludensdomain/dto/GamePagingDto.java
+++ b/src/main/java/com/ludensdomain/dto/GamePagingDto.java
@@ -13,10 +13,10 @@ public class GamePagingDto {
 
     int size;
 
-    String developer;
+    long developer;
 
-    String publisher;
+    long publisher;
 
-    String genre;
+    long genre;
 
 }

--- a/src/main/resources/mapper/GameMapper.xml
+++ b/src/main/resources/mapper/GameMapper.xml
@@ -26,8 +26,7 @@
                  LEFT OUTER JOIN publisher ON G.publisher = P.id
                  LEFT OUTER JOIN status ON G.status = S.id
         WHERE G.id = #{gameId}
-        AND G.status = 3
-        OR G.status = 4
+        AND (G.status = 3 OR G.status = 4)
     </select>
 
     <select id="getGameList" parameterType="com.ludensdomain.dto.GamePagingDto" resultType="com.ludensdomain.dto.GameDto">
@@ -47,10 +46,10 @@
                P.name publisherName,
                S.name statusName
         FROM game G
-        LEFT OUTER JOIN genre ON G.genre = R.id
-        LEFT OUTER JOIN developer ON G.developer = D.id
-        LEFT OUTER JOIN publisher ON G.publisher = P.id
-        LEFT OUTER JOIN status ON G.status = S.id
+        LEFT OUTER JOIN genre R ON G.genre = R.id
+        LEFT OUTER JOIN developer D ON G.developer = D.id
+        LEFT OUTER JOIN publisher P ON G.publisher = P.id
+        LEFT OUTER JOIN status S ON G.status = S.id
             <if test="genre != null and genre != ''">
                 AND G.genre = #{genre}
             </if>
@@ -60,9 +59,8 @@
             <if test="publisher != null and publisher != ''">
                 AND G.publisher = #{publisher}
             </if>
-        WHERE <![CDATA[G.id < #{lastGameId}]]>
-        AND G.status = 3
-        OR G.status = 4
+        WHERE <![CDATA[G.id > #{lastGameId}]]>
+        AND (G.status = 3 OR G.status = 4)
         ORDER BY G.release_date
         LIMIT ${size}
     </select>

--- a/src/main/resources/mapper/GameMapper.xml
+++ b/src/main/resources/mapper/GameMapper.xml
@@ -21,10 +21,10 @@
                P.name publisherName,
                S.name statusName
         FROM game G
-                 LEFT OUTER JOIN genre ON G.genre = R.id
-                 LEFT OUTER JOIN developer ON G.developer = D.id
-                 LEFT OUTER JOIN publisher ON G.publisher = P.id
-                 LEFT OUTER JOIN status ON G.status = S.id
+                 LEFT OUTER JOIN genre R ON G.genre = R.id
+                 LEFT OUTER JOIN developer D ON G.developer = D.id
+                 LEFT OUTER JOIN publisher P ON G.publisher = P.id
+                 LEFT OUTER JOIN status S ON G.status = S.id
         WHERE G.id = #{gameId}
         AND (G.status = 3 OR G.status = 4)
     </select>
@@ -61,7 +61,7 @@
             </if>
         WHERE <![CDATA[G.id > #{lastGameId}]]>
         AND (G.status = 3 OR G.status = 4)
-        ORDER BY G.release_date
+        ORDER BY G.id
         LIMIT ${size}
     </select>
 

--- a/src/main/resources/mapper/GameMapper.xml
+++ b/src/main/resources/mapper/GameMapper.xml
@@ -20,7 +20,7 @@
                D.name developerName,
                P.name publisherName,
                S.name statusName
-        FROM game G, genre R, developer D, publisher P, status S
+        FROM game G
                  LEFT OUTER JOIN genre ON G.genre = R.id
                  LEFT OUTER JOIN developer ON G.developer = D.id
                  LEFT OUTER JOIN publisher ON G.publisher = P.id
@@ -46,7 +46,7 @@
                D.name developerName,
                P.name publisherName,
                S.name statusName
-        FROM game G, genre R, developer D, publisher P, status S
+        FROM game G
         LEFT OUTER JOIN genre ON G.genre = R.id
         LEFT OUTER JOIN developer ON G.developer = D.id
         LEFT OUTER JOIN publisher ON G.publisher = P.id


### PR DESCRIPTION
## MySQL 실행 계획
옵티마이저가 파싱된 쿼리문을 토대로 어떤 방식으로 데이터를 다룰지 예상하는 계획표

### 목표
- 디스크 IO와 시간을 감소해 더 효율적인 쿼리문 작성
- 쿼리문 로직이나 기타 수정할 곳 보완

### 문제
게임 리스트를 가져오는 쿼리문을 처음 호출할 때 시간이 오래 걸림
- OR 절에서 풀 테이블 스캔이 이뤄짐
- ORDER BY의 기준점인 게임 출시 날짜에서 Using filesort 옵션이 사용됨
쿼리문이 정상 작동하지만 더 효율적으로 가져오는 방법이 있을지 확인

### 해결
1. OR 절을 AND절과 같이 괄호로 넣어줘 레인지 스캔이 되도록 변경
2. ORDER BY에서 인덱스가 있는 게임의 아이디를 지정해 인덱스를 사용하도록 변경